### PR TITLE
Update to 2.38.1. JB#58886

### DIFF
--- a/rpm/util-linux.spec
+++ b/rpm/util-linux.spec
@@ -170,6 +170,12 @@ The uuidd package contains a userspace daemon (uuidd) which guarantees
 uniqueness of time-based UUID generation even at very high rates on
 SMP systems.
 
+%package -n cfdisk
+License:        GPLv2+
+Summary:        cfdisk is a curses-based program for partitioning any block device
+
+%description -n cfdisk
+%{summary}.
 
 %prep
 %setup -q -n %{name}-%{version}/%{name}
@@ -389,7 +395,6 @@ exit 0
 %{_bindir}/fincore
 %{_bindir}/unshare
 /sbin/sfdisk
-/sbin/cfdisk
 
 /bin/raw
 /bin/wdctl
@@ -524,3 +529,7 @@ exit 0
 %{_libdir}/libuuid.so
 %{_includedir}/uuid
 %{_libdir}/pkgconfig/uuid.pc
+
+%files -n cfdisk
+%defattr(-,root,root)
+/sbin/cfdisk


### PR DESCRIPTION
- The doc subpackage no longer generated. Here it could make sense a bit
    more than elsewhere, but the new version is using rubygem-asciidoctor
    which based on fedora packaging requires some 10 other rubygems. Which
    themselves probably require some more. Packaging all those wouldn't feel
    worth the effort just to generate commonly not installed doc package
    here.
- Simplified /etc/mtab creation similar to what Fedora has done.
- Some tools no longer available, some new have appeared.
- Removed bunch of packaging cruft.

Also split cfdisk to subpackage as it's the only tool using libncursesw. JB#55520

@mkosola @Tomin1 @saukko 