### PR TITLE
[util-linux] Disable CD-ROM probing in blkid_probe_set_device. JB#61678

### DIFF
--- a/rpm/0001-libblkid-probe-Disable-CD-ROM-probing-in-blkid_probe.patch
+++ b/rpm/0001-libblkid-probe-Disable-CD-ROM-probing-in-blkid_probe.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikita Ukhrenkov <nikita.ukhrenkov@jolla.com>
+Date: Thu, 28 Mar 2024 16:32:09 +0200
+Subject: [PATCH] libblkid: (probe) Disable CD-ROM probing in
+ blkid_probe_set_device
+
+---
+ libblkid/src/probe.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libblkid/src/probe.c b/libblkid/src/probe.c
+index 5acd2732c026d6b5635b966b7c7a469bf65047f2..6437c393203c196999eae5291ee609ea42754a1b 100644
+--- a/libblkid/src/probe.c
++++ b/libblkid/src/probe.c
+@@ -1011,7 +1011,7 @@ int blkid_probe_set_device(blkid_probe pr, int fd,
+ 		pr->flags |= BLKID_FL_NOSCAN_DEV;
+ 	}
+ 
+-#ifdef CDROM_GET_CAPABILITY
++#if 0 && defined(CDROM_GET_CAPABILITY)
+ 	else if (S_ISBLK(sb.st_mode) &&
+ 	    !blkid_probe_is_tiny(pr) &&
+ 	    !dm_uuid &&

--- a/rpm/util-linux.spec
+++ b/rpm/util-linux.spec
@@ -28,6 +28,8 @@ Source12:       util-linux-su-l.pamd
 Source14:       util-linux-runuser.pamd
 Source15:       util-linux-runuser-l.pamd
 
+Patch0:         0001-libblkid-probe-Disable-CD-ROM-probing-in-blkid_probe.patch
+
 ### Obsoletes & Conflicts & Provides
 # docs no longer generated due to needing lots of dependencies via rubygem-asciidoctor
 Obsoletes: util-linux-doc <= 2.38.1
@@ -178,7 +180,7 @@ Summary:        cfdisk is a curses-based program for partitioning any block devi
 %{summary}.
 
 %prep
-%setup -q -n %{name}-%{version}/%{name}
+%autosetup -p1 -n %{name}-%{version}/%{name}
 
 %build
 # Because .git dir isn't included in tar_git, we explicitly state


### PR DESCRIPTION
Workaround kernel crash on some Unisoc devices due to ioctl number collision with ufs_sprd driver ioctls.